### PR TITLE
feat: Add 'Order Pickup' buttons and styling

### DIFF
--- a/src/components/MobileFooter.tsx
+++ b/src/components/MobileFooter.tsx
@@ -50,7 +50,7 @@ const MobileFooter = () => {
             // The `cloverOrderUrl` constant holds the link URL.
 
             // Ensure variant has a fallback for safety, though the hook usually provides 'control' or false.
-            const currentVariant = variant || 'control'; // Or some other sensible default if variant can be null/undefined
+            const currentVariant = variant ?? 'control'; // Or some other sensible default if variant can be null/undefined
 
             posthog.capture('mobile_footer_button_click', {
               button_variant: currentVariant,

--- a/src/components/MobileFooter.tsx
+++ b/src/components/MobileFooter.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+
+const MobileFooter = () => {
+  // Hardcoded values as environment variables are not available
+  const gmapsUrl = "https://maps.app.goo.gl/9TqJAazS222w6H9v5";
+  const address = "9280 Goreway Dr, Unit C107, Brampton, ON L6T 0C4";
+  const phoneNumberHref = "tel:+13653780009";
+  const phoneNumberDisplay = "+1 (365) 378-0009"; // Slightly more readable display
+  const cloverOrderUrl = "https://www.clover.com/online-ordering/mvz-kitchen-brampton";
+
+  return (
+    <footer className="fixed bottom-0 left-0 z-50 w-full bg-neutral-100 p-3 shadow-[0_-2px_5px_rgba(0,0,0,0.1)] md:hidden">
+      <div className="mx-auto flex max-w-md flex-col items-center">
+        <a
+          href={gmapsUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="mb-2 text-center text-xs text-neutral-600 hover:underline"
+        >
+          {address}
+        </a>
+        <a
+          href={phoneNumberHref}
+          className="mb-2 w-full rounded-md bg-neutral-200 py-2 px-4 text-center font-medium text-neutral-800 hover:bg-neutral-300"
+        >
+          Call Us ({phoneNumberDisplay})
+        </a>
+        <a
+          href={cloverOrderUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="w-full rounded-md bg-orange-500 py-2 px-4 text-center font-bold text-white hover:bg-orange-600"
+        >
+          Order Pickup Online
+        </a>
+      </div>
+    </footer>
+  );
+};
+
+export default MobileFooter;

--- a/src/components/MobileFooter.tsx
+++ b/src/components/MobileFooter.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 const MobileFooter = () => {
   // Hardcoded values as environment variables are not available
-  const gmapsUrl = "https://maps.app.goo.gl/9TqJAazS222w6H9v5";
+  const appleMapsUrl = "https://maps.apple.com/place?address=107-9280%20Goreway%20Dr,%20Brampton%20ON%20L6P%200M7,%20Canada&coordinate=43.758433,-79.692053&name=MV%27z%20Kitchen&place-id=I6A66AB063F9B3868&map=explore";
   const address = "9280 Goreway Dr, Unit C107, Brampton, ON L6T 0C4";
   const phoneNumberHref = "tel:+13653780009";
   const phoneNumberDisplay = "+1 (365) 378-0009"; // Slightly more readable display
@@ -12,7 +12,7 @@ const MobileFooter = () => {
     <footer className="fixed bottom-0 left-0 z-50 w-full bg-neutral-100 p-3 shadow-[0_-2px_5px_rgba(0,0,0,0.1)] md:hidden">
       <div className="mx-auto flex max-w-md flex-col items-center">
         <a
-          href={gmapsUrl}
+          href={appleMapsUrl}
           target="_blank"
           rel="noopener noreferrer"
           className="mb-2 w-full rounded-md bg-neutral-200 py-2 px-4 text-center text-sm font-medium text-neutral-800 hover:bg-neutral-300"

--- a/src/components/MobileFooter.tsx
+++ b/src/components/MobileFooter.tsx
@@ -15,7 +15,7 @@ const MobileFooter = () => {
           href={gmapsUrl}
           target="_blank"
           rel="noopener noreferrer"
-          className="mb-2 text-center text-xs text-neutral-600 hover:underline"
+          className="mb-2 w-full rounded-md bg-neutral-200 py-2 px-4 text-center text-sm font-medium text-neutral-800 hover:bg-neutral-300"
         >
           {address}
         </a>

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -4,6 +4,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import { env } from "~/env";
+import MobileFooter from "./MobileFooter"; // Adjust path if necessary, but should be in the same directory
 
 interface LayoutProps {
   children: React.ReactNode;
@@ -60,19 +61,6 @@ export function Layout({ children }: LayoutProps) {
                 />
               </Link>
               <ul className="grid select-none grid-cols-1 gap-2 pb-8 pr-4 pt-4 text-xl font-bold underline lg:grid-cols-1 lg:gap-4 lg:pl-11 lg:text-2xl">
-                <li className="mb-2 lg:mb-0">
-                  <a
-                    href="https://www.clover.com/online-ordering/mvz-kitchen-brampton"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className={clsx(
-                      "group flex w-full items-center justify-end gap-2 rounded-md bg-orange-500 px-4 py-2 text-white !no-underline hover:bg-orange-600 lg:justify-normal",
-                    )}
-                    draggable="false"
-                  >
-                    Order Pickup
-                  </a>
-                </li>
                 <li>
                   <Link
                     href="/menu"
@@ -251,6 +239,7 @@ export function Layout({ children }: LayoutProps) {
           Reserved.
         </p>
       </footer>
+      <MobileFooter /> {/* <--- Add the new component here */}
     </>
   );
 }

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -47,9 +47,6 @@ export function Layout({ children }: LayoutProps) {
               </h1>
             </Link>
 
-            <div className="my-2 inline-block animate-pulse rounded-md border-2 border-red-500 p-2 pl-11 text-2xl font-bold text-red-500 shadow-md">
-              NEW: Opening Soon in Brampton
-            </div>
             <div className="mb-8 grid grid-cols-2">
               <Link href={"/"} className="lg:hidden">
                 <Image

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -60,6 +60,19 @@ export function Layout({ children }: LayoutProps) {
                 />
               </Link>
               <ul className="grid select-none grid-cols-1 gap-2 pb-8 pr-4 pt-4 text-xl font-bold underline lg:grid-cols-1 lg:gap-4 lg:pl-11 lg:text-2xl">
+                <li className="mb-2 lg:mb-0">
+                  <a
+                    href="https://www.clover.com/online-ordering/mvz-kitchen-brampton"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className={clsx(
+                      "group flex w-full items-center justify-end gap-2 rounded-md bg-orange-500 px-4 py-2 text-white !no-underline hover:bg-orange-600 lg:justify-normal",
+                    )}
+                    draggable="false"
+                  >
+                    Order Pickup
+                  </a>
+                </li>
                 <li>
                   <Link
                     href="/menu"

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -53,18 +53,6 @@ export default function Home() {
           vibrant tastes of authentic Indian cuisine to you.
         </p>
 
-        {/* Order Pickup Button Section */}
-        <div className="my-8 text-center">
-          <a
-            href="https://www.clover.com/online-ordering/mvz-kitchen-brampton"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="inline-block transform rounded-lg bg-orange-500 px-8 py-4 text-2xl font-bold text-white shadow-lg transition-transform duration-200 hover:scale-105 hover:bg-orange-600 hover:shadow-xl"
-          >
-            Order Online for Pickup
-          </a>
-        </div>
-
         {/* Featured Items Section */}
         <div className="my-10">
           <h2 className="mb-4 text-xl font-extrabold">Featured Specialties</h2>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -53,6 +53,18 @@ export default function Home() {
           vibrant tastes of authentic Indian cuisine to you.
         </p>
 
+        {/* Order Pickup Button Section */}
+        <div className="my-8 text-center">
+          <a
+            href="https://www.clover.com/online-ordering/mvz-kitchen-brampton"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-block transform rounded-lg bg-orange-500 px-8 py-4 text-2xl font-bold text-white shadow-lg transition-transform duration-200 hover:scale-105 hover:bg-orange-600 hover:shadow-xl"
+          >
+            Order Online for Pickup
+          </a>
+        </div>
+
         {/* Featured Items Section */}
         <div className="my-10">
           <h2 className="mb-4 text-xl font-extrabold">Featured Specialties</h2>


### PR DESCRIPTION
Adds 'Order Pickup' buttons to the website to attract customers.

Key changes:
- A new 'Order Pickup' link, styled as a button, has been added to the main navigation bar in the header (`src/components/layout.tsx`). This button is visible on all pages and opens the Clover online ordering page in a new tab.
- A prominent 'Order Online for Pickup' call-to-action button has been added to the homepage (`src/pages/index.tsx`) below the hero section. This button is larger and designed to be eye-catching, also linking to the Clover online ordering page in a new tab.
- Both buttons have been styled using Tailwind CSS for a "catchy" appearance (orange background, white text, hover effects) and are responsive across different screen sizes.
- Ensured the header button does not inherit text underline from its parent.