### PR TITLE
feat: add redirect from /full_menu to /menu

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -43,6 +43,23 @@ const config = {
 
   // This is required to support PostHog trailing slash API requests
   skipTrailingSlashRedirect: true,
+
+  async redirects() {
+    return [
+      {
+        source: '/full_menu',
+        destination: '/menu',
+        permanent: true,
+        has: [
+          {
+            type: 'query',
+            key: 'utm_source',
+            value: 'in_store_tv',
+          },
+        ],
+      },
+    ]
+  },
 };
 
 export default config;


### PR DESCRIPTION
This commit adds a redirect from /full_menu?utm_source=in_store_tv to /menu. This is to ensure users accessing the old URL are correctly routed to the new menu page.